### PR TITLE
Simplifying poetry pkg hook name and clarifying output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,16 +10,32 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  POETRY_VERSION: "1.4.2"
+  PYTHON_VERSION: "3.9"
+
 jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: tatari-tv/github-actions/checkout@v3
-      - uses: tatari-tv/github-actions/poetry-install@v3
+      - uses: actions/checkout@v3
+      - name: Setup Python ${{env.PYTHON_VERSION}}
+        uses: actions/setup-python@v4
         with:
-          cache-site-packages: true
+          python-version: ${{env.PYTHON_VERSION}}
+      - name: Install Poetry
+        shell: bash
+        run: |
+          pip3 install poetry==${{env.POETRY_VERSION}}
+          poetry config virtualenvs.create false
+      - name: Install Poetry Dependencies
+        env:
+          PYTHONUSERBASE: ""
+          SETUPTOOLS_USE_DISTUTILS: "stdlib"
+        shell: bash
+        run: poetry install
       - run: make unit-test
 
   lint:
@@ -27,10 +43,22 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: tatari-tv/github-actions/checkout@v3
-      - uses: tatari-tv/github-actions/poetry-install@v3
+      - uses: actions/checkout@v3
+      - name: Setup Python ${{env.PYTHON_VERSION}}
+        uses: actions/setup-python@v4
         with:
-          cache-site-packages: true
+          python-version: ${{env.PYTHON_VERSION}}
+      - name: Install Poetry
+        shell: bash
+        run: |
+          pip3 install poetry==${{env.POETRY_VERSION}}
+          poetry config virtualenvs.create false
+      - name: Install Poetry Dependencies
+        env:
+          PYTHONUSERBASE: ""
+          SETUPTOOLS_USE_DISTUTILS: "stdlib"
+        shell: bash
+        run: poetry install
       - run: make lint
 
   type-check:
@@ -38,8 +66,20 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: tatari-tv/github-actions/checkout@v3
-      - uses: tatari-tv/github-actions/poetry-install@v3
+      - uses: actions/checkout@v3
+      - name: Setup Python ${{env.PYTHON_VERSION}}
+        uses: actions/setup-python@v4
         with:
-          cache-site-packages: true
+          python-version: ${{env.PYTHON_VERSION}}
+      - name: Install Poetry
+        shell: bash
+        run: |
+          pip3 install poetry==${{env.POETRY_VERSION}}
+          poetry config virtualenvs.create false
+      - name: Install Poetry Dependencies
+        env:
+          PYTHONUSERBASE: ""
+          SETUPTOOLS_USE_DISTUTILS: "stdlib"
+        shell: bash
+        run: poetry install
       - run: make type-check

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
-- id: poetry-pkg-dep-constraint-format
-  name: poetry-pkg-dep-constraint-format
+- id: poetry-pkg-constraints
+  name: poetry-pkg-constraints
   description: Evaluate if Poetry dependency constraints for packages follow Tatari's standards
-  entry: poetry run python -m python_hooks.poetry_pkg_dep_constraints
+  entry: poetry run python -m python_hooks.poetry_pkg_constraints
   language: python
   pass_filenames: false
   files: ^(.*/)?pyproject.toml$

--- a/python_hooks/poetry_pkg_constraints.py
+++ b/python_hooks/poetry_pkg_constraints.py
@@ -33,6 +33,7 @@ def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
             print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
             exit_status = 1
 
+    print('All package constraints should use ^ (or less ideally >=) when defining versions\nFor example: python = "^3.10"')
     return exit_status
 
 

--- a/tests/python/test_poetry_pkg_dep_constraints.py
+++ b/tests/python/test_poetry_pkg_dep_constraints.py
@@ -2,7 +2,7 @@ from os.path import dirname
 
 from pytest import raises
 
-from python_hooks.poetry_pkg_dep_constraints import validate_constraints
+from python_hooks.poetry_pkg_constraints import validate_constraints
 
 
 def test_good_pyproject():


### PR DESCRIPTION
## Summary
<!--
Describe your changes and motivations. Give context about assumptions or chosen
solution, as well as issues fixed if applicable.
-->
Updates to Poetry package dependency constraint format check hook.  Simpler is better.

## Testing
<!--
Include here any tests that you are taking before merging this PR. These may
include migrations, merging depending > PRs as well as infrastructure plan
changes. Provide instructions so reviewers can reproduce.
-->
Tested locally with `pre-commit try-repo`:
```bash
❯ poetry run pre-commit try-repo ../pre-commit-hooks poetry-pkg-constraints --all-files
Warning: In a future version of Poetry, PyPI will be disabled automatically if at least one custom source is configured with another priority than 'explicit'. In order to avoid a breaking change and make your pyproject.toml forward compatible, add PyPI explicitly via 'poetry source add pypi'. By the way, this has the advantage that you can set the priority of PyPI as with any other source.
[WARNING] Creating temporary repo with uncommitted changes...
===============================================================================
Using config:
===============================================================================
repos:
-   repo: /var/folders/df/vs9h3qsj713_2g060d7shzz80000gn/T/tmpbh8srxam/shadow-repo
    rev: 530e229befdefae70d49666888935fa3044e823f
    hooks:
    -   id: poetry-pkg-constraints
===============================================================================
[INFO] Initializing environment for /var/folders/df/vs9h3qsj713_2g060d7shzz80000gn/T/tmpbh8srxam/shadow-repo.
[INFO] Installing environment for /var/folders/df/vs9h3qsj713_2g060d7shzz80000gn/T/tmpbh8srxam/shadow-repo.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
poetry-pkg-constraints.....................................................Failed
- hook id: poetry-pkg-constraints
- exit code: 1

Warning: In a future version of Poetry, PyPI will be disabled automatically if at least one custom source is configured with another priority than 'explicit'. In order to avoid a breaking change and make your pyproject.toml forward compatible, add PyPI explicitly via 'poetry source add pypi'. By the way, this has the advantage that you can set the priority of PyPI as with any other source.
INCORRECT FORMAT: python = "~3.10"
All package constraints should use ^ (or less ideally >=) when defining versions
 For example: python = "^3.10"
```