### PR TITLE
pre-commit check for import of forbidden classes

### DIFF
--- a/python_hooks/forbidden_imports.py
+++ b/python_hooks/forbidden_imports.py
@@ -1,10 +1,10 @@
+import argparse
 import ast
 import sys
-import argparse
 
 
 def check_imports(filename, forbidden_classes):
-    with open(filename, 'r') as file:
+    with open(filename) as file:
         tree = ast.parse(file.read(), filename=filename)
 
     for node in tree.body:
@@ -15,14 +15,15 @@ def check_imports(filename, forbidden_classes):
                     return 1  # Indicates failure
     return 0  # Indicates success
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Check for specific imports')
     parser.add_argument('--forbidden_classes', nargs='+', help='Names of the classes to check in imports')
-    parser.add_argument('file_list', nargs='+', help='List of files to check') # provided by the pre-commit call
+    parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()
 
     classes_to_check = args.forbidden_classes
-    if not forbidden_classes:
+    if not classes_to_check:
         raise ValueError("No classes to check provided. add `args: ['--forbidden_classes', 'foo', 'bar', '--']` to the pre-commit config")
 
     file_list = args.file_list

--- a/python_hooks/forbidden_imports.py
+++ b/python_hooks/forbidden_imports.py
@@ -1,0 +1,34 @@
+import ast
+import sys
+import argparse
+
+
+def check_imports(filename, forbidden_classes):
+    with open(filename, 'r') as file:
+        tree = ast.parse(file.read(), filename=filename)
+
+    for node in tree.body:
+        if isinstance(node, ast.Import) | isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name in forbidden_classes:
+                    print(f"Flagged import of {alias.name} in {filename}")
+                    return 1  # Indicates failure
+    return 0  # Indicates success
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Check for specific imports')
+    parser.add_argument('--forbidden_classes', nargs='+', help='Names of the classes to check in imports')
+    parser.add_argument('file_list', nargs='+', help='List of files to check') # provided by the pre-commit call
+    args = parser.parse_args()
+
+    classes_to_check = args.forbidden_classes
+    if not forbidden_classes:
+        raise ValueError("No classes to check provided. add `args: ['--forbidden_classes', 'foo', 'bar', '--']` to the pre-commit config")
+
+    file_list = args.file_list
+    return_code = 0
+
+    for file_path in file_list:
+        return_code |= check_imports(file_path, classes_to_check)
+
+    sys.exit(return_code)

--- a/tests/python/data/forbidden_imports_sample.py
+++ b/tests/python/data/forbidden_imports_sample.py
@@ -1,0 +1,5 @@
+from datetime import date
+import tuple
+from datetime import datetime
+
+pass

--- a/tests/python/data/forbidden_imports_sample.py
+++ b/tests/python/data/forbidden_imports_sample.py
@@ -1,5 +1,8 @@
 from datetime import date
-import tuple
 from datetime import datetime
 
-pass
+import tuple
+
+do_something_with_date = date(2023, 1, 1)
+do_something_with_datetime = datetime(2023, 1, 1, 1, 1)
+do_something_with_tuple = tuple(1, 2)

--- a/tests/python/data/forbidden_imports_sample.py
+++ b/tests/python/data/forbidden_imports_sample.py
@@ -1,8 +1,10 @@
 from datetime import date
 from datetime import datetime
 
+import pandas as pd
 import tuple
 
 do_something_with_date = date(2023, 1, 1)
 do_something_with_datetime = datetime(2023, 1, 1, 1, 1)
 do_something_with_tuple = tuple(1, 2)
+df = pd.DataFrame()

--- a/tests/python/data/forbidden_imports_sample.py
+++ b/tests/python/data/forbidden_imports_sample.py
@@ -1,10 +1,9 @@
+import enum as en
+from dataclasses import dataclass
 from datetime import date
 from datetime import datetime
 
-import pandas as pd
-import tuple
-
 do_something_with_date = date(2023, 1, 1)
 do_something_with_datetime = datetime(2023, 1, 1, 1, 1)
-do_something_with_tuple = tuple(1, 2)
-df = pd.DataFrame()
+do_something_with_dataclass = dataclass()
+do_something_with_enum = en.Enum('foo', 'bar')

--- a/tests/python/test_forbidden_imports.py
+++ b/tests/python/test_forbidden_imports.py
@@ -1,0 +1,21 @@
+from python_hooks.forbidden_imports import check_imports
+
+from os.path import dirname
+
+from pytest import raises
+
+from python_hooks.poetry_app_constraints import validate_constraints
+
+
+def test_good_imports():
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['SomeOKClass', 'AnotherOKClass']) == 0
+
+# sample file imports date from datetime, which we will say is forbidden
+def test_bad_from_imports():
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['date', 'AnotherOKClass']) == 1
+
+
+# sample file imports tuple, which we will say is forbidden
+def test_bad_imports():
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['tuple']) == 1
+

--- a/tests/python/test_forbidden_imports.py
+++ b/tests/python/test_forbidden_imports.py
@@ -15,3 +15,8 @@ def test_bad_from_imports():
 # sample file imports tuple, which we will say is forbidden
 def test_bad_imports():
     assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['tuple']) == 1
+
+
+# sample file imports pandas aliased pd, which we will say is forbidden
+def test_bad_imports_aliased():
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['pandas']) == 1

--- a/tests/python/test_forbidden_imports.py
+++ b/tests/python/test_forbidden_imports.py
@@ -1,14 +1,11 @@
-from python_hooks.forbidden_imports import check_imports
-
 from os.path import dirname
 
-from pytest import raises
-
-from python_hooks.poetry_app_constraints import validate_constraints
+from python_hooks.forbidden_imports import check_imports
 
 
 def test_good_imports():
     assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['SomeOKClass', 'AnotherOKClass']) == 0
+
 
 # sample file imports date from datetime, which we will say is forbidden
 def test_bad_from_imports():
@@ -18,4 +15,3 @@ def test_bad_from_imports():
 # sample file imports tuple, which we will say is forbidden
 def test_bad_imports():
     assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['tuple']) == 1
-

--- a/tests/python/test_forbidden_imports.py
+++ b/tests/python/test_forbidden_imports.py
@@ -12,11 +12,11 @@ def test_bad_from_imports():
     assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['date', 'AnotherOKClass']) == 1
 
 
-# sample file imports tuple, which we will say is forbidden
+# sample file imports dataclass, which we will say is forbidden
 def test_bad_imports():
-    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['tuple']) == 1
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['dataclass']) == 1
 
 
-# sample file imports pandas aliased pd, which we will say is forbidden
+# sample file imports enum aliased en, which we will say is forbidden
 def test_bad_imports_aliased():
-    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['pandas']) == 1
+    assert check_imports(f'{dirname(__file__)}/data/forbidden_imports_sample.py', ['enum']) == 1


### PR DESCRIPTION
JIRA [DAT-2548](https://tatari.atlassian.net/browse/DAT-2548)

## Summary
<!--
-->
we want to flag files using certain classes in some of our projects. this should do the trick, with customizable forbidden class arg passed from pre-commit-config.yaml


## Testing
<!--
his PR. These may
include migrations, merging depending > PRs as well as infrastructure plan
changes. Provide instructions so reviewers can reproduce.
-->
i've run this locally from airflow-dags by creating a python file referenced thusly from the pre-commit config:
```
  - repo: local
    hooks:
      - id: test-pre-commit
        name: "test pre commit"
        entry: python dags/hello_pre_commit.py
        language: python
        types: [python]
        args: ['--forbidden_classes', 'TriggerDagRunOperator', 'VaultIssueSecretIDMixin', '--']
        exclude: services/tatari_trigger_dag_run\.py
```
which yielded expected results. (i added multiple forbidden classes in the args because wanted to make sure it worked with >1, on individual and all files, which it did. ultimately the caller will only use TriggerDagRunOperator. 


## Validation
<!--
Include here any steps to take after merging this PR to verify changes were
successful.  These may include apply new migrations, verify datadog monitors,
check logs or closely follow notifications.
-->
once merged i'm going to try calling the github hook from the airflow-staging repo and merge there if all works. 


[DAT-2548]: https://tatari.atlassian.net/browse/DAT-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ