### PR TITLE
expose forbidden-imports in pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,6 +21,6 @@
 - id: forbidden-imports
   name: forbidden-imports
   description: Check for forbidden imports specified in args bn
-  entry: python python_hooks/forbidden_imports.py
+  entry: python -m python_hooks.forbidden_imports
   language: python
   types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,9 @@
   entry: bash_hooks/gitleaks.sh
   language: script
   pass_filenames: false
+- id: forbidden-imports
+  name: forbidden-imports
+  description: Check for forbidden imports specified in args bn
+  entry: python python_hooks/forbidden_imports.py
+  language: python
+  types: [python]


### PR DESCRIPTION
followup needed to expose the function to callers. will iterate on how this needs to work with the venv since caller does not reliably have 

was able to call this from https://github.com/tatari-tv/airflow-dags/pull/5859
it worked locally and on the ci

called it by referencing rev SHA:
```
  - repo: https://github.com/tatari-tv/pre-commit-hooks
    rev: ebeac2945af0d5e08c17276bddd4cff04bf392da
    hooks:
      - id: forbidden-imports
        args: ['--forbidden_classes', 'TriggerDagRunOperator', '--']
        exclude: services/tatari_trigger_dag_run\.py
```


## Summary
<!--
Describe your changes and motivations. Give context about assumptions or chosen
solution, as well as issues fixed if applicable.
-->

## Testing
<!--
Include here any tests that you are taking before merging this PR. These may
include migrations, merging depending > PRs as well as infrastructure plan
changes. Provide instructions so reviewers can reproduce.
-->

## Validation
<!--
Include here any steps to take after merging this PR to verify changes were
successful.  These may include apply new migrations, verify datadog monitors,
check logs or closely follow notifications.
-->
