### PR TITLE
DAT-2888 - fix transitive dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# jetbrains
+.idea/

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,3 +30,7 @@
   entry: python -m python_hooks.dockerfile_poetry
   language: python
   files: .*Dockerfile.*
+- id: deptry
+  name: deptry
+  entry: bash_hooks/deptry.sh
+  language: script

--- a/bash_hooks/deptry.sh
+++ b/bash_hooks/deptry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+output=$(poetry run deptry . 2>&1)
+status=$?
+
+if [ $status -ne 0 ]; then
+    echo "$output"
+    exit $status
+fi


### PR DESCRIPTION
https://tatari.atlassian.net/browse/DAT-2888

## Summary
The main bulk of this work will be fixing the repos, however we also want to add this as a pre-commit hook so it won't get introduced right back into the code base.

Aside from flagging refs of deps by proxy (transitive deps), deptry will also flag 3 other things that are good to catch https://deptry.com/rules-violations/

Changes still need to be added to cookiecutter to support.

## Testing

Tested manually with [pyspark-data-science-jobs](https://github.com/tatari-tv/pyspark-data-science-jobs/compare/DAT-2888/deps_by_proxy..main)

output was as follows:
```
pyproject.toml: DEP002 'delta-spark' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'freezegun' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pypi' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'jupyter' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'types-six' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'types-python-dateutil' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'types-pyyaml' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'cmake' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'papermill' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'types-pytz' defined as a dependency but not used in the codebase
pyspark_data_science_jobs/algorithms/lowess.py:1:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/algorithms/lowess.py:2:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/algorithms/lowess.py:3:1: DEP003 'statsmodels' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/campaign_review_output/campaign_review_output.py:10:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/drag_factor/notebook/closed-loop-visual-analysis-view-through.ipynb:2:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/drag_factor/notebook/closed-loop-visual-analysis-view-through.ipynb:3:1: DEP003 'IPython' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/drag_factor/notebook/closed-loop-visual-analysis.ipynb:2:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/drag_factor/notebook/closed-loop-visual-analysis.ipynb:8:1: DEP003 'IPython' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/calculation/simba/baseline_simulation/baseline_simulation.py:8:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/closed_loop_base.py:12:1: DEP003 'tatari_data_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/closed_loop/ingestion/dedupe_spotview_data/dedupe_spotview_data.py:11:1: DEP003 'tatari_data_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/creds/__init__.py:1:1: DEP003 'tatari_vault_client' imported but it is a transitive dependency
pyspark_data_science_jobs/experian/job/audience_similarity_score_etl.py:8:8: DEP003 'tatari_metrics' imported but it is a transitive dependency
pyspark_data_science_jobs/geo_test/data.py:3:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/geo_test/data.py:7:1: DEP003 'tatari_data_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/holdout_test/notebooks/budget_estimation.py:3:8: DEP003 'scipy' imported but it is a transitive dependency
pyspark_data_science_jobs/job/base.py:3:1: DEP003 'tatari_data_common' imported but it is a transitive dependency
pyspark_data_science_jobs/notebooks/reach_frequency/linear_frequency_response.py:2:8: DEP003 'matplotlib' imported but it is a transitive dependency
pyspark_data_science_jobs/notebooks/reach_frequency/linear_frequency_response.py:3:8: DEP003 'matplotlib' imported but it is a transitive dependency
pyspark_data_science_jobs/notebooks/traffic_review/Webtraffic_review_notebook.py:6:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/data.py:5:1: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/label_encoding.py:1:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/model.py:6:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/model.py:7:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/model_base.py:7:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/model_base.py:8:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/preprocessing.py:4:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/preprocessing.py:5:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/s3.py:4:1: DEP003 'botocore' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/stages/feature_refresh.py:5:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/stages/fit_and_predict.py:7:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/stages/fit_and_predict.py:8:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/predict_cpx/versioned_persist_s3.py:7:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/reach_frequency/demo_rf/linear_demo_rf.py:5:1: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/reach_frequency/frequency_response/linear.py:1:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/reach_frequency/geo_rf/linear_geo_rf.py:5:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/reach_frequency/linear_audience_overlap/linear_audience_overlap.py:3:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/similar_inventory/calculation/analysis.py:1:8: DEP003 'tatari_metrics' imported but it is a transitive dependency
pyspark_data_science_jobs/similar_inventory/calculation/analysis.py:9:1: DEP003 'tatari_experian_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/similar_inventory/calculation/util.py:1:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/similar_inventory/calculation/util.py:2:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/sqw_publisher_overlap_calculation/base_sketch_generation.py:3:1: DEP003 'tatari_experian_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/sqw_publisher_overlap_calculation/utils.py:11:1: DEP003 'tatari_data_utils' imported but it is a transitive dependency
pyspark_data_science_jobs/streaming_drag_factor/drag_factor_output.py:3:8: DEP003 'matplotlib' imported but it is a transitive dependency
pyspark_data_science_jobs/streaming_drag_factor/drag_factor_output.py:4:8: DEP003 'matplotlib' imported but it is a transitive dependency
pyspark_data_science_jobs/streaming_drag_factor/drag_factor_output.py:5:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/job/notebook_automation/util_functions.py:9:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/job/notebook_automation/util_functions.py:15:1: DEP003 'IPython' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/job/notebook_automation/webtraffic-review-notebook-automation.ipynb:4:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/notebook_utils/plot.py:10:8: DEP003 'numpy' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/notebook_utils/plot.py:11:8: DEP003 'pandas' imported but it is a transitive dependency
pyspark_data_science_jobs/traffic_review/notebook_utils/plot.py:19:1: DEP003 'IPython' imported but it is a transitive dependency
Found 62 dependency issues.
```

