### PR TITLE
fix for ignoring multiple identifiers on one line

### DIFF
--- a/python_hooks/utills/ignore_check.py
+++ b/python_hooks/utills/ignore_check.py
@@ -17,12 +17,12 @@ def ignore_check(filename: str, check_fails: list[IdentifierCheck], noqa_string:
     Checks each failed line for a noqa_string comment, and removes the check if it is found.
     Returns the number of checks remaining.
     """
-    # check_fails_no_ignores = []
     with open(filename) as file:
         failing_lines = [check.line for check in check_fails]
         for i, line in enumerate(file):
             if i + 1 in failing_lines:
-                for check in check_fails:
-                    if check.line == i + 1 and noqa_string in line:
+                # there can be multiple IdentifierChecks per line
+                for check in [check for check in check_fails if check.line == i + 1]:
+                    if noqa_string in line:
                         check_fails.remove(check)
     return check_fails

--- a/tests/python/data/disallowed_sample.py
+++ b/tests/python/data/disallowed_sample.py
@@ -4,6 +4,8 @@ stringy.split('!!')
 stringy.replace('!!', '!!')
 stringy.splitlines()
 stringy.split('!!')  # tatari-noqa
+stringy.split('!!')[0].split('a')  # tatari-noqa
+(stringy.split('!!')[0].split('a'))  # tatari-noqa
 
 
 class FooDisallowedAttr:

--- a/tests/python/data/disallowed_sample.py
+++ b/tests/python/data/disallowed_sample.py
@@ -8,10 +8,10 @@ stringy.split('!!')[0].split('a')  # tatari-noqa
 # autopep8: off
 # fmt: off
 stringo = (
-    stringy
+    stringy  # tatari-noqa
     .split('!!')[0]
     .split('a')
-)   # tatari-noqa
+)
 
 
 class FooDisallowedAttr:

--- a/tests/python/data/disallowed_sample.py
+++ b/tests/python/data/disallowed_sample.py
@@ -5,7 +5,13 @@ stringy.replace('!!', '!!')
 stringy.splitlines()
 stringy.split('!!')  # tatari-noqa
 stringy.split('!!')[0].split('a')  # tatari-noqa
-(stringy.split('!!')[0].split('a'))  # tatari-noqa
+# autopep8: off
+# fmt: off
+stringo = (
+    stringy
+    .split('!!')[0]
+    .split('a')
+)   # tatari-noqa
 
 
 class FooDisallowedAttr:

--- a/tests/python/test_disallowed_identifiers.py
+++ b/tests/python/test_disallowed_identifiers.py
@@ -32,9 +32,9 @@ def test_check_identifiers_function(mock_ignore_check, mock_print):
             IdentifierCheck('split', 'splitlines', 3, 0),
             IdentifierCheck('split', 'splitlines', 6, 0),
             IdentifierCheck('split', 'splitlines', 7, 0),
-            IdentifierCheck('split', 'splitlines', 9, 4),
+            IdentifierCheck('split', 'splitlines', 11, 4),
             IdentifierCheck('split', 'splitlines', 7, 0),
-            IdentifierCheck('split', 'splitlines', 9, 4),
+            IdentifierCheck('split', 'splitlines', 11, 4),
         ],
     )
 
@@ -66,7 +66,7 @@ def test_check_identifiers_attribute(mock_ignore_check, mock_print):
     assert mock_ignore_check.call_count == 1
     assert mock_ignore_check.call_args == call(
         FILE,
-        [IdentifierCheck('disallowed', 'allowed', 18, 9), IdentifierCheck('disallowed', 'allowed', 19, 5)],
+        [IdentifierCheck('disallowed', 'allowed', 23, 9), IdentifierCheck('disallowed', 'allowed', 24, 5)],
     )
 
     mock_print.assert_has_calls(

--- a/tests/python/test_disallowed_identifiers.py
+++ b/tests/python/test_disallowed_identifiers.py
@@ -31,6 +31,10 @@ def test_check_identifiers_function(mock_ignore_check, mock_print):
             IdentifierCheck('split', 'splitlines', 2, 0),
             IdentifierCheck('split', 'splitlines', 3, 0),
             IdentifierCheck('split', 'splitlines', 6, 0),
+            IdentifierCheck('split', 'splitlines', 7, 0),
+            IdentifierCheck('split', 'splitlines', 9, 4),
+            IdentifierCheck('split', 'splitlines', 7, 0),
+            IdentifierCheck('split', 'splitlines', 9, 4),
         ],
     )
 
@@ -54,7 +58,7 @@ def test_check_identifiers_function(mock_ignore_check, mock_print):
 @patch('python_hooks.disallowed_identifiers.ignore_check')
 def test_check_identifiers_attribute(mock_ignore_check, mock_print):
     mock_ignore_check.return_value = [
-        IdentifierCheck('disallowed', 'allowed', 15, 9),
+        IdentifierCheck('disallowed', 'allowed', 19, 9),
     ]
     actual_return = check_identifiers(FILE, Identifier.attribute, ['disallowed'], ['allowed'])
 
@@ -62,14 +66,14 @@ def test_check_identifiers_attribute(mock_ignore_check, mock_print):
     assert mock_ignore_check.call_count == 1
     assert mock_ignore_check.call_args == call(
         FILE,
-        [IdentifierCheck('disallowed', 'allowed', 15, 9), IdentifierCheck('disallowed', 'allowed', 16, 5)],
+        [IdentifierCheck('disallowed', 'allowed', 18, 9), IdentifierCheck('disallowed', 'allowed', 19, 5)],
     )
 
     mock_print.assert_has_calls(
         [
             call(
                 DISALLOWED_MESSAGE.format(
-                    identifier=Identifier.attribute, name='disallowed', filename=FILE, line=15, col_offset=9, replacement='allowed'
+                    identifier=Identifier.attribute, name='disallowed', filename=FILE, line=19, col_offset=9, replacement='allowed'
                 )
             ),
         ]

--- a/tests/python/test_disallowed_identifiers.py
+++ b/tests/python/test_disallowed_identifiers.py
@@ -15,9 +15,8 @@ from python_hooks.utills.ignore_check import IdentifierCheck
 FILE = f'{dirname(__file__)}/data/disallowed_sample.py'
 
 
-@patch('builtins.print')
 @patch('python_hooks.disallowed_identifiers.ignore_check')
-def test_check_identifiers_function(mock_ignore_check, mock_print):
+def test_check_identifiers_function(mock_ignore_check):
     mock_ignore_check.return_value = [
         IdentifierCheck('split', 'splitlines', 2, 0),
         IdentifierCheck('split', 'splitlines', 3, 0),
@@ -38,25 +37,27 @@ def test_check_identifiers_function(mock_ignore_check, mock_print):
         ],
     )
 
-    mock_print.assert_has_calls(
-        [
-            call(
-                DISALLOWED_MESSAGE.format(
-                    identifier=Identifier.function, name='split', filename=FILE, line=2, col_offset=0, replacement='splitlines'
-                )
-            ),
-            call(
-                DISALLOWED_MESSAGE.format(
-                    identifier=Identifier.function, name='split', filename=FILE, line=3, col_offset=0, replacement='splitlines'
-                )
-            ),
-        ]
-    )
+
+@patch('python_hooks.disallowed_identifiers.print')
+def test_check_identifiers_function_and_ignore(mock_print):
+    actual_return = check_identifiers(FILE, Identifier.function, ['split'], ['splitlines'])
+    assert actual_return == 1
+    mock_print.call_args_list == [
+        call(
+            DISALLOWED_MESSAGE.format(
+                identifier=Identifier.function, name='split', filename=FILE, line=2, col_offset=0, replacement='splitlines'
+            )
+        ),
+        call(
+            DISALLOWED_MESSAGE.format(
+                identifier=Identifier.function, name='split', filename=FILE, line=3, col_offset=0, replacement='splitlines'
+            )
+        ),
+    ]
 
 
-@patch('builtins.print')
 @patch('python_hooks.disallowed_identifiers.ignore_check')
-def test_check_identifiers_attribute(mock_ignore_check, mock_print):
+def test_check_identifiers_attribute(mock_ignore_check):
     mock_ignore_check.return_value = [
         IdentifierCheck('disallowed', 'allowed', 19, 9),
     ]
@@ -69,15 +70,18 @@ def test_check_identifiers_attribute(mock_ignore_check, mock_print):
         [IdentifierCheck('disallowed', 'allowed', 23, 9), IdentifierCheck('disallowed', 'allowed', 24, 5)],
     )
 
-    mock_print.assert_has_calls(
-        [
-            call(
-                DISALLOWED_MESSAGE.format(
-                    identifier=Identifier.attribute, name='disallowed', filename=FILE, line=19, col_offset=9, replacement='allowed'
-                )
-            ),
-        ]
-    )
+
+@patch('python_hooks.disallowed_identifiers.print')
+def test_check_identifiers_attribute_and_ignore(mock_print):
+    actual_return = check_identifiers(FILE, Identifier.attribute, ['split'], ['splitlines'])
+    assert actual_return == 1
+    mock_print.call_args_list == [
+        call(
+            DISALLOWED_MESSAGE.format(
+                identifier=Identifier.attribute, name='disallowed', filename=FILE, line=19, col_offset=9, replacement='allowed'
+            )
+        ),
+    ]
 
 
 @patch('builtins.print')

--- a/tests/python/test_disallowed_identifiers.py
+++ b/tests/python/test_disallowed_identifiers.py
@@ -42,7 +42,7 @@ def test_check_identifiers_function(mock_ignore_check):
 def test_check_identifiers_function_and_ignore(mock_print):
     actual_return = check_identifiers(FILE, Identifier.function, ['split'], ['splitlines'])
     assert actual_return == 1
-    mock_print.call_args_list == [
+    assert mock_print.call_args_list == [
         call(
             DISALLOWED_MESSAGE.format(
                 identifier=Identifier.function, name='split', filename=FILE, line=2, col_offset=0, replacement='splitlines'
@@ -73,12 +73,12 @@ def test_check_identifiers_attribute(mock_ignore_check):
 
 @patch('python_hooks.disallowed_identifiers.print')
 def test_check_identifiers_attribute_and_ignore(mock_print):
-    actual_return = check_identifiers(FILE, Identifier.attribute, ['split'], ['splitlines'])
+    actual_return = check_identifiers(FILE, Identifier.attribute, ['disallowed'], ['allowed'])
     assert actual_return == 1
-    mock_print.call_args_list == [
+    assert mock_print.call_args_list == [
         call(
             DISALLOWED_MESSAGE.format(
-                identifier=Identifier.attribute, name='disallowed', filename=FILE, line=19, col_offset=9, replacement='allowed'
+                identifier=Identifier.attribute, name='disallowed', filename=FILE, line=23, col_offset=9, replacement='allowed'
             )
         ),
     ]

--- a/tests/python/test_utils/test_ignore_check.py
+++ b/tests/python/test_utils/test_ignore_check.py
@@ -7,13 +7,17 @@ def test_ignore_check():
         IdentifierCheck('split', 'splitlines', 2, 0),
         IdentifierCheck('split', 'splitlines', 3, 0),
         IdentifierCheck('split', 'splitlines', 6, 0),  # this line is annotated in the test data file (FILE)
-        IdentifierCheck('disallowed', 'allowed', 15, 9),
-        IdentifierCheck('disallowed', 'allowed', 16, 5),  # this line is annotated in the test data file (FILE)
+        IdentifierCheck('split', 'splitlines', 7, 0),  # this line is annotated in the test data file (FILE)
+        IdentifierCheck('split', 'splitlines', 7, 0),  # this line is annotated in the test data file (FILE)
+        IdentifierCheck('split', 'splitlines', 11, 0),  # this line is annotated in the test data file (FILE)
+        IdentifierCheck('split', 'splitlines', 11, 0),  # this line is annotated in the test data file (FILE)
+        IdentifierCheck('disallowed', 'allowed', 23, 9),
+        IdentifierCheck('disallowed', 'allowed', 24, 5),  # this line is annotated in the test data file (FILE)
     ]
     expected_annotated_check_fails = [
         IdentifierCheck('split', 'splitlines', 2, 0),
         IdentifierCheck('split', 'splitlines', 3, 0),
-        IdentifierCheck('disallowed', 'allowed', 15, 9),
+        IdentifierCheck('disallowed', 'allowed', 23, 9),
     ]
     filename = 'tests/python/data/disallowed_sample.py'
     assert ignore_check(filename, input_check_fails) == expected_annotated_check_fails


### PR DESCRIPTION
bug fix, so no jira. 
i caught this whilst applying to the calc jobs repo: 

```python

        return (
            period.select(F.col('week_period.range').alias('range')) # flagged line
            .union(period.select(F.col('previous_two_week_period.range')))
            .union(period.select(F.col('following_two_week_period.range')))
            .union(period.select(F.col('month_period.range')))
            .union(period.select(F.col('quarter_period.range')))
            .cache()
        )

```
where the flagged line caught: 
```
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
```

adding `#tatari-noqa` to that line didn't solve all of the calls:
```
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
Flagged function union in pyspark_calculation_jobs/reach_frequency_histogram/job/reach_frequency_histogram_etl.py:81 column 12. Replace with unionByName
```

that's because each Identifier check was evaluated for match once with a `# tatari-noqa` string, and then removed. thus >1 identifier attributed to 1 line would not be ignored. 

using this rev in the calc jobs repo fixes the problem.

## Summary
<!--
Describe your changes and motivations. Give context about assumptions or chosen
solution, as well as issues fixed if applicable.
-->

## Testing
<!--
Include here any tests that you are taking before merging this PR. These may
include migrations, merging depending > PRs as well as infrastructure plan
changes. Provide instructions so reviewers can reproduce.
-->

## Validation
<!--
Include here any steps to take after merging this PR to verify changes were
successful.  These may include apply new migrations, verify datadog monitors,
check logs or closely follow notifications.
-->
