### PR TITLE
Refactor deptry hook.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -38,8 +38,9 @@
   files: .*Dockerfile.*
 - id: deptry
   name: deptry
-  entry: bash_hooks/deptry.sh
-  language: script
+  entry: poetry run deptry .
+  language: system
+  pass_filenames: false
 - id: do-not-support-generated-columns
   name: do-not-support-generated-columns
   entry: python -m python_hooks.do_not_support_generated_columns

--- a/bash_hooks/deptry.sh
+++ b/bash_hooks/deptry.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-output=$(poetry run deptry . 2>&1)
-status=$?
-
-if [ $status -ne 0 ]; then
-    echo "$output"
-    exit $status
-fi


### PR DESCRIPTION
Follow on for https://github.com/tatari-tv/pre-commit-hooks/pull/10
this simplifies and I think fixes a possible issue with repeated output. Tried with local setup in pdsj repo with success:
```
  - repo: local
    hooks:
      - id: deptry
        name: deptry
        entry: poetry run deptry .
        language: system
        pass_filenames: false
```