### PR TITLE
DAT-2927 - Add validate_branch_name hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -46,3 +46,9 @@
   entry: python -m python_hooks.do_not_support_generated_columns
   language: python
   types: [sql]
+- id: validate-branch-name
+  name: validate-branch-name
+  description: Checks that branch name is in the expected format
+  entry: python -m python_hooks.validate_branch_name
+  language: python
+  types: [python]

--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -1,0 +1,23 @@
+import re
+import sys
+from subprocess import check_output
+
+
+# regex patterns for acceptable branch names
+# the only current check enforces the branch name is in a valid docker tag format (see https://docs.docker.com/reference/cli/docker/image/tag/), and also allows forward slashes.
+# we also restrict the branch name to be 50 characters or less, because that makes sense.
+EXPECTED_PATTERN = r"^(?![-.])[a-zA-Z0-9._/-]{1,50}$"
+ERROR_MESSAGE = "branch name can't start with hyphen or period, cant be more than 50 characters, and can only contain letters, numbers, and special the characters: ._-/"
+
+
+def validate_branch_name(branch) -> int:
+    if re.match(EXPECTED_PATTERN, branch):
+        return 0
+    print(ERROR_MESSAGE)
+    return 1
+
+
+if __name__ == "__main__":
+    branch = check_output(['git', 'symbolic-ref', '--short', 'HEAD']).strip().decode('utf-8')
+    return_code = validate_branch_name(branch)
+    sys.exit(return_code)

--- a/tests/python/test_validate_branch_name.py
+++ b/tests/python/test_validate_branch_name.py
@@ -1,0 +1,19 @@
+from python_hooks.validate_branch_name import validate_branch_name
+
+
+def test_validate_branch_name():
+    branch_names_with_exit_code = [
+        ("UPPER-12345/lower", 0),
+        ("lower-12345/UPPER", 0),
+        ("ABC-123/with-dash", 0),
+        ("ABC-123/with_underscore", 0),
+        ("ABC-123/with-dash_and_underscore", 0),
+        ("ABC-123/with-dash_and_underscore.and.period", 0),
+        (".ABC12345/abcdABC", 1),  # starts with period
+        ("-ABC12345/abcdABC", 1),  # starts with hyphen
+        ("once_upon_a_time_there_was_a_branch_name_that_told_a_very_long_story", 1),  # over 50 characters
+        ("ABC-123/abc&123", 1),  # includes non-allowed symbols
+    ]
+
+    for branch, exit_code in branch_names_with_exit_code:
+        assert validate_branch_name(branch) == exit_code

--- a/tests/python/test_validate_branch_name.py
+++ b/tests/python/test_validate_branch_name.py
@@ -3,6 +3,7 @@ from python_hooks.validate_branch_name import validate_branch_name
 
 def test_validate_branch_name():
     branch_names_with_exit_code = [
+        ("simplebranch", 0),
         ("UPPER-12345/lower", 0),
         ("lower-12345/UPPER", 0),
         ("ABC-123/with-dash", 0),


### PR DESCRIPTION
https://tatari.atlassian.net/browse/DAT-2927

## Summary
Draft PR for now. Putting this up for discussion. Restricting all special characters from branch names (aside from underscore and hyphen) would be the simpler way to go here. But seems like we might just want to enforce the [recommended best practice](https://tatari.atlassian.net/wiki/spaces/SRE/pages/703463551/Managing+Git+Branch+Naming+Conventions#Recommended-Practices). 

I also added the hotfix option, which isn't really an agreed upon convention but seems like it could be. 

usage:

`.pre-commit-hooks.yaml`:
```
...

  - repo: https://github.com/tatari-tv/pre-commit-hooks
    rev: vX.X.X
    hooks:
      - id: validate_branch_name
```

## Testing / Validation
Ran locally via ` python ./python_hooks/validate_branch_name.py` after with validly and invalidly named branches.
