### PR TITLE
fix detached head state issue in validate_branch_name

### DIFF
--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -18,6 +18,7 @@ def validate_branch_name(branch) -> int:
 
 
 if __name__ == "__main__":
-    branch = check_output(['git', 'symbolic-ref', '--short', 'HEAD']).strip().decode('utf-8')
+    commit = check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
+    branch = check_output(["git", "branch", "--contains", commit]).strip().decode('utf-8').split('\n')[-1].strip(' *')
     return_code = validate_branch_name(branch)
     sys.exit(return_code)


### PR DESCRIPTION
https://tatari.atlassian.net/browse/DAT-2927

## Summary
Follow on fix, the hook [hits an issue](https://github.com/tatari-tv/pyspark-data-science-jobs/actions/runs/9035444258/job/24830235040?pr=402) when running in `ci`, this is due to git having checkout out the most recent commit on the branch.

## Testing / Validation
Tested these changes under the problematic conditions in pyspark-data-science-jobs
