### PR TITLE
DAT-2827 - Update poetry-app/pkg-constraints to check all constraints

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,6 +9,7 @@
 - id: poetry-pkg-constraints
   name: poetry-pkg-constraints
   description: Evaluate if Poetry dependency constraints for packages follow Tatari's standards
+  additional_dependencies: [toml]
   entry: poetry run python -m python_hooks.poetry_pkg_constraints
   language: python
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,7 @@
 - id: poetry-app-constraints
   name: poetry-app-constraints
   description: Evaluate if Poetry dependency constraints for application follow Tatari's standards
+  additional_dependencies: [toml]
   entry: poetry run python -m python_hooks.poetry_app_constraints
   language: python
   pass_filenames: false

--- a/python_hooks/poetry_app_constraints.py
+++ b/python_hooks/poetry_app_constraints.py
@@ -39,7 +39,7 @@ def validate_python_constraint(dep_name: str, constraint: str) -> int:
     # Regex match on supported formats
     if not match(r'~', constraint):
         print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
-        print('Applications shoule use ~ when defining python version. For example: python = "~3.10"')
+        print('Applications should use ~ when defining python version. For example: python = "~3.10"')
         return 1
 
     return 0

--- a/python_hooks/poetry_app_constraints.py
+++ b/python_hooks/poetry_app_constraints.py
@@ -1,14 +1,16 @@
 '''
 Validate dependency constraint formats for Python application repos.
 
-Currently supported format(s): ~
+Python version constraint currently supported format: ~
+Package version constraint currently supported format: ^
 '''
+from argparse import ArgumentParser
 from re import match
 
 from toml import load
 
 
-def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
+def validate_constraints(ignore: list[str], pyproject_path: str = 'pyproject.toml') -> int:
     exit_status = 0
 
     # Load pyproject.toml as Python object
@@ -16,11 +18,6 @@ def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
 
     # Iterate over all dependencies to get constraints
     for dep_name, dep_value in pyproject['tool']['poetry']['dependencies'].items():
-        # TODO: Remove this logic which only checks for python constraints
-        # Eventually want to validate all deps
-        if dep_name != 'python':
-            continue
-
         # Handle special cases of version definitions, e.g.:
         # dep = {"version" = "^1.0.0"}
         try:
@@ -28,14 +25,38 @@ def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
         except TypeError:
             constraint = dep_value
 
-        # Regex match on supported formats
-        if not match(r'~', constraint):
-            print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
-            exit_status = 1
-
-    print('All package constraints should use ~ when defining versions\nFor example: python = "~3.10"')
+        if dep_name == 'python':
+            exit_status = validate_python_constraint(dep_name, constraint)
+        elif dep_name not in ignore:
+            if exit_status != 0:
+                validate_package_constraint(dep_name, constraint)
+            else:
+                exit_status = validate_package_constraint(dep_name, constraint)
     return exit_status
 
 
+def validate_python_constraint(dep_name: str, constraint: str) -> int:
+    # Regex match on supported formats
+    if not match(r'~', constraint):
+        print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
+        print('Applications shoule use ~ when defining python version\nFor example: python = "~3.10"')
+        return 1
+
+    return 0
+
+
+def validate_package_constraint(dep_name: str, constraint: str) -> int:
+    # Regex match on supported formats
+    if not match(r'\^', constraint):
+        print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
+        print('All application package constraints should use ^ when defining version\nFor example:  tatari-metrics = "^1.0.1"')
+        return 1
+
+    return 0
+
+
 if __name__ == '__main__':
-    exit(validate_constraints())
+    parser = ArgumentParser(description="Validate dependency constraint formats for Python application repos.")
+    parser.add_argument("--ignore", nargs='+', default=[], help="List of packages to ignore constraint checking for.")
+    args = parser.parse_args()
+    exit(validate_constraints(args.ignore))

--- a/python_hooks/poetry_app_constraints.py
+++ b/python_hooks/poetry_app_constraints.py
@@ -39,7 +39,7 @@ def validate_python_constraint(dep_name: str, constraint: str) -> int:
     # Regex match on supported formats
     if not match(r'~', constraint):
         print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
-        print('Applications shoule use ~ when defining python version\nFor example: python = "~3.10"')
+        print('Applications shoule use ~ when defining python version. For example: python = "~3.10"')
         return 1
 
     return 0
@@ -49,7 +49,7 @@ def validate_package_constraint(dep_name: str, constraint: str) -> int:
     # Regex match on supported formats
     if not match(r'\^', constraint):
         print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
-        print('All application package constraints should use ^ when defining version\nFor example:  tatari-metrics = "^1.0.1"')
+        print('All application package constraints should use ^ when defining version. For example:  tatari-metrics = "^1.0.1"')
         return 1
 
     return 0

--- a/python_hooks/poetry_pkg_constraints.py
+++ b/python_hooks/poetry_pkg_constraints.py
@@ -47,7 +47,7 @@ def validate_python_constraint(dep_name: str, constraint: str) -> int:
 
 def validate_package_constraint(dep_name: str, constraint: str) -> int:
     # Regex match on supported formats
-    if not match(r'>=', constraint) or not (match(r'>=', constraint) and match(r'<=', constraint)):
+    if not match(r'>=', constraint) or (match(r'>=', constraint) and match(r'.*<=', constraint)):
         print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
         print('Package constraints should use >= when defining versions. For example: tatari-pyspark = ">=1.0.14"')
         return 1

--- a/python_hooks/poetry_pkg_constraints.py
+++ b/python_hooks/poetry_pkg_constraints.py
@@ -1,14 +1,16 @@
 '''
 Validate dependency constraint formats for Python package repos.
 
-Currently supported formats are ^ and >=.
+Python version constraint currently supported formats are ^ and >=.
+Package version constraint currently supported format: >=
 '''
+from argparse import ArgumentParser
 from re import match
 
 from toml import load
 
 
-def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
+def validate_constraints(ignore: list[str], pyproject_path: str = 'pyproject.toml') -> int:
     exit_status = 0
 
     # Load pyproject.toml as Python object
@@ -16,11 +18,6 @@ def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
 
     # Iterate over all dependencies to get constraints
     for dep_name, dep_value in pyproject['tool']['poetry']['dependencies'].items():
-        # TODO: Remove this logic which only checks for python constraints
-        # Eventually want to validate all deps
-        if dep_name != 'python':
-            continue
-
         # Handle special cases of version definitions, e.g.:
         # dep = {"version" = "^1.0.0"}
         try:
@@ -28,14 +25,38 @@ def validate_constraints(pyproject_path: str = 'pyproject.toml') -> int:
         except TypeError:
             constraint = dep_value
 
-        # Regex match on supported formats
-        if not match(r'(\^|>=)', constraint):
-            print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
-            exit_status = 1
-
-    print('All package constraints should use ^ (or less ideally >=) when defining versions\nFor example: python = "^3.10"')
+        if dep_name == 'python':
+            exit_status = validate_python_constraint(dep_name, constraint)
+        elif dep_name not in ignore:
+            if exit_status != 0:
+                validate_package_constraint(dep_name, constraint)
+            else:
+                exit_status = validate_package_constraint(dep_name, constraint)
     return exit_status
 
 
+def validate_python_constraint(dep_name: str, constraint: str) -> int:
+    # Regex match on supported formats
+    if not match(r'(\^|>=)', constraint):
+        print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
+        print('Packages should use ^ (or less ideally >=) when defining python versions. For example: python = "^3.10"')
+        return 1
+
+    return 0
+
+
+def validate_package_constraint(dep_name: str, constraint: str) -> int:
+    # Regex match on supported formats
+    if not match(r'>=', constraint) or not (match(r'>=', constraint) and match(r'<=', constraint)):
+        print(f'INCORRECT FORMAT: {dep_name} = "{constraint}"')
+        print('Package constraints should use >= when defining versions. For example: tatari-pyspark = ">=1.0.14"')
+        return 1
+
+    return 0
+
+
 if __name__ == '__main__':
-    exit(validate_constraints())
+    parser = ArgumentParser(description="Validate dependency constraint formats for Python package repos.")
+    parser.add_argument("--ignore", nargs='+', default=[], help="List of packages to ignore constraint checking for.")
+    args = parser.parse_args()
+    exit(validate_constraints(args.ignore))

--- a/tests/python/data/app_bad_pyproject.toml
+++ b/tests/python/data/app_bad_pyproject.toml
@@ -1,2 +1,0 @@
-[tool.poetry.dependencies]
-python = "3.9"

--- a/tests/python/data/app_good_pyproject.toml
+++ b/tests/python/data/app_good_pyproject.toml
@@ -1,2 +1,0 @@
-[tool.poetry.dependencies]
-python = "~3.9"

--- a/tests/python/data/pkg_bad_pyproject.toml
+++ b/tests/python/data/pkg_bad_pyproject.toml
@@ -1,2 +1,0 @@
-[tool.poetry.dependencies]
-python = "~3.9"

--- a/tests/python/data/pkg_good_pyproject.toml
+++ b/tests/python/data/pkg_good_pyproject.toml
@@ -1,2 +1,0 @@
-[tool.poetry.dependencies]
-python = "^3.9"

--- a/tests/python/test_poetry_app_constraints.py
+++ b/tests/python/test_poetry_app_constraints.py
@@ -1,18 +1,42 @@
+import tempfile
 from os.path import dirname
 
 from pytest import raises
 
 from python_hooks.poetry_app_constraints import validate_constraints
+from tests.python.test_utils.test_toml import write_pyproject_toml
 
 
-def test_good_pyproject():
-    assert validate_constraints(f'{dirname(__file__)}/data/app_good_pyproject.toml') == 0
+def test_validate_constraints_correct_python():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"python": "~3.10"})
+        assert validate_constraints([], pyproject) == 0
 
 
-def test_bad_pyproject():
-    assert validate_constraints(f'{dirname(__file__)}/data/app_bad_pyproject.toml') == 1
+def test_validate_constraints_incorrect_python():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"python": "^3.10"})
+        assert validate_constraints([], pyproject) == 1
+
+
+def test_validate_constraints_correct_pkg():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"tatari-foo": "^3.10", "tatari-bar": "^3.13"})
+        assert validate_constraints([], pyproject) == 0
+
+
+def test_validate_constraints_incorrect_pkg():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"tatari-foo": ">=3.10"})
+        assert validate_constraints([], pyproject) == 1
+        pyproject2 = write_pyproject_toml(temp_dir, {"tatari-foo": "3.10"})
+        assert validate_constraints([], pyproject2) == 1
+        pyproject3 = write_pyproject_toml(temp_dir, {"tatari-foo": ">=3.3.2,<=3.4.1"})
+        assert validate_constraints([], pyproject3) == 1
+        pyproject4 = write_pyproject_toml(temp_dir, {"tatari-foo": "~3.4.1"})
+        assert validate_constraints([], pyproject4) == 1
 
 
 def test_missing_pyproject():
     with raises(FileNotFoundError):
-        validate_constraints(f'{dirname(__file__)}/data/missing_pyproject.toml')
+        validate_constraints([], f'{dirname(__file__)}/data/missing_pyproject.toml')

--- a/tests/python/test_poetry_pkg_constraints.py
+++ b/tests/python/test_poetry_pkg_constraints.py
@@ -1,18 +1,42 @@
+import tempfile
 from os.path import dirname
 
 from pytest import raises
 
 from python_hooks.poetry_pkg_constraints import validate_constraints
+from tests.python.test_utils.test_toml import write_pyproject_toml
 
 
-def test_good_pyproject():
-    assert validate_constraints(f'{dirname(__file__)}/data/pkg_good_pyproject.toml') == 0
+def test_validate_constraints_correct_python():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"python": "^3.10"})
+        assert validate_constraints([], pyproject) == 0
 
 
-def test_bad_pyproject():
-    assert validate_constraints(f'{dirname(__file__)}/data/pkg_bad_pyproject.toml') == 1
+def test_validate_constraints_incorrect_python():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"python": "~3.10"})
+        assert validate_constraints([], pyproject) == 1
+
+
+def test_validate_constraints_correct_pkg():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"tatari-foo": ">=3.10", "tatari-bar": ">=3.13"})
+        assert validate_constraints([], pyproject) == 0
+
+
+def test_validate_constraints_incorrect_pkg():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject = write_pyproject_toml(temp_dir, {"tatari-foo": "^3.10"})
+        assert validate_constraints([], pyproject) == 1
+        pyproject2 = write_pyproject_toml(temp_dir, {"tatari-foo": "3.10"})
+        assert validate_constraints([], pyproject2) == 1
+        pyproject3 = write_pyproject_toml(temp_dir, {"tatari-foo": ">=3.3.2,<=3.4.1"})
+        assert validate_constraints([], pyproject3) == 1
+        pyproject4 = write_pyproject_toml(temp_dir, {"tatari-foo": "~3.4.1"})
+        assert validate_constraints([], pyproject4) == 1
 
 
 def test_missing_pyproject():
     with raises(FileNotFoundError):
-        validate_constraints(f'{dirname(__file__)}/data/missing_pyproject.toml')
+        validate_constraints([], f'{dirname(__file__)}/data/missing_pyproject.toml')

--- a/tests/python/test_utils/test_toml.py
+++ b/tests/python/test_utils/test_toml.py
@@ -1,0 +1,12 @@
+import os
+
+import toml
+
+
+def write_pyproject_toml(temp_dir: str, deps: dict[str, str]) -> str:
+    toml_file_path = os.path.join(temp_dir, "pyproject.toml")
+    data = {"tool": {"poetry": {"dependencies": deps}}}
+    with open(toml_file_path, "w") as toml_file:
+        toml.dump(data, toml_file)
+
+    return toml_file_path


### PR DESCRIPTION
https://tatari.atlassian.net/browse/DAT-2827

## Summary
We want to update pyspark cookie cutters, pyspark repos, package cookiecutter, and at least some package repos to use these updated hooks. These will flag dependencies that don't adhere to the [dependency constraints best practices](https://tatari.atlassian.net/wiki/spaces/SRE/pages/405700968/Python+Software+Development+Policy#Dependency-Constraints)

## Testing
Tested changes in both hooks by copying the code changes into a repo and running using a local pre-commit hook.

[poetry-pkg-constraints](https://github.com/tatari-tv/python-tatari-pyspark-framework/commit/2d8f3bd86a1cd87922dee93a5f5343d8d95a1ad2) 
[poetry-app-constraints](https://github.com/tatari-tv/pyspark-data-science-jobs/commit/6768160c3dba64a7aee46bed111ff1c9cab9ca50)

