### PR TITLE
SRE-3596 Remove poetry run from hook entries

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: poetry-app-constraints
   description: Evaluate if Poetry dependency constraints for application follow Tatari's standards
   additional_dependencies: [toml]
-  entry: poetry run python -m python_hooks.poetry_app_constraints
+  entry: python -m python_hooks.poetry_app_constraints
   language: python
   pass_filenames: false
   files: ^(.*/)?pyproject.toml$
@@ -10,7 +10,7 @@
   name: poetry-pkg-constraints
   description: Evaluate if Poetry dependency constraints for packages follow Tatari's standards
   additional_dependencies: [toml]
-  entry: poetry run python -m python_hooks.poetry_pkg_constraints
+  entry: python -m python_hooks.poetry_pkg_constraints
   language: python
   pass_filenames: false
   files: ^(.*/)?pyproject.toml$


### PR DESCRIPTION
SRE-3596

## Summary

- Remove `poetry run` prefix from `poetry-app-constraints` and `poetry-pkg-constraints` hook entries
- `language: python` hooks already have the package installed in their venv, so `poetry run` is unnecessary
- Fixes compatibility with `prek` (Rust-based pre-commit runner) which doesn't have `poetry` in its sandbox

## Test plan

- [x] All 58 existing tests pass
- [ ] Verify in a downstream repo that hooks work with both `pre-commit` and `prek`