### PR TITLE
SRE-3704: add console script entry points for prek compatibility (v1.6.0)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: poetry-app-constraints
   description: Evaluate if Poetry dependency constraints for application follow Tatari's standards
   additional_dependencies: [toml]
-  entry: python -m python_hooks.poetry_app_constraints
+  entry: poetry-app-constraints
   language: python
   pass_filenames: false
   files: ^(.*/)?pyproject.toml$
@@ -10,7 +10,7 @@
   name: poetry-pkg-constraints
   description: Evaluate if Poetry dependency constraints for packages follow Tatari's standards
   additional_dependencies: [toml]
-  entry: python -m python_hooks.poetry_pkg_constraints
+  entry: poetry-pkg-constraints
   language: python
   pass_filenames: false
   files: ^(.*/)?pyproject.toml$
@@ -23,19 +23,19 @@
 - id: forbidden-imports
   name: forbidden-imports
   description: Check for forbidden imports specified in args bn
-  entry: python -m python_hooks.forbidden_imports
+  entry: forbidden-imports
   language: python
   types: [python]
 - id: disallowed-identifiers
   name: disallowed-identifiers
   description: Check for disallowed identifiers specified in args bn
-  entry: python -m python_hooks.disallowed_identifiers
+  entry: disallowed-identifiers
   language: python
   types: [python]
 - id: dockerfile-poetry
   name: dockerfile-poetry
   description: Check if Dockerfile specifies a poetry version on install
-  entry: python -m python_hooks.dockerfile_poetry
+  entry: dockerfile-poetry
   language: python
   files: .*Dockerfile.*
 - id: deptry
@@ -45,32 +45,32 @@
   pass_filenames: false
 - id: do-not-support-generated-columns
   name: do-not-support-generated-columns
-  entry: python -m python_hooks.do_not_support_generated_columns
+  entry: do-not-support-generated-columns
   language: python
   types: [sql]
 - id: validate-branch-name
   name: validate-branch-name
   description: Checks that branch name is in the expected format
-  entry: python -m python_hooks.validate_branch_name
+  entry: validate-branch-name
   language: python
   types: [python]
   pass_filenames: false
 - id: image-tag-branch-constraint
   name: image-tag-branch-constraint
   description: Check for image_tag and branch
-  entry: python -m python_hooks.image_tag_branch_constraint
+  entry: image-tag-branch-constraint
   language: python
   types: [python]
 - id: no-non-spark-buckets-in-spark-projects
   name: no-non-spark-buckets-in-spark-projects
   description: Check for non-Spark bucket imports in projects using tatari-pyspark or tatari-ml-utils
   additional_dependencies: [toml]
-  entry: python -m python_hooks.no_non_spark_buckets_in_spark_projects
+  entry: no-non-spark-buckets-in-spark-projects
   language: python
   types: [python]
 - id: no-boto3-in-airflow-dags
   name: no-boto3-in-airflow-dags
   description: Prevent direct boto3 imports that cause scheduler abuse via parse-time AWS calls
-  entry: python -m python_hooks.no_boto3_in_airflow_dags
+  entry: no-boto3-in-airflow-dags
   language: python
   types: [python]

--- a/README.md
+++ b/README.md
@@ -7,25 +7,47 @@ Place to store all of Tatari's custom [pre-commit hooks](https://pre-commit.com/
 
 ## Adding a new hook
 
-Depending in which language your hook is written, you will need to commit your hook script in different locations:
-* [Python](https://pre-commit.com/#python): [python_hooks/](./python_hooks)
-  * Ensure you add any dependencies necessary for your hook by running `poetry add <dep>` followed by `poetry lock`
-* [Bash](https://pre-commit.com/#system): root of repo
+### Python hooks
 
-Then define your hook in [.pre-commit-hooks.yaml](./.pre-commit-hooks.yaml).  Full format of hook definition can be found
-[here](https://pre-commit.com/#creating-new-hooks).
+1. **Write the module** in [`python_hooks/`](./python_hooks).  Add a no-arg `main()` function that is the CLI entry point:
 
-Python example:
-```yaml
-- id: python-example
-  name: python-example
-  description: Run a Python pre-commit hook
-  entry: poetry run python -m python_hooks.python_script.py
-  language: python
-  pass_filenames: false
-```
+   ```python
+   def main():
+       """CLI entry point for the my-hook pre-commit hook."""
+       parser = argparse.ArgumentParser(...)
+       args = parser.parse_args()
+       sys.exit(run(args))
 
-Bash example:
+   if __name__ == "__main__":
+       main()
+   ```
+
+2. **Register the console script** in [`pyproject.toml`](./pyproject.toml) under `[tool.poetry.scripts]`:
+
+   ```toml
+   [tool.poetry.scripts]
+   my-hook = "python_hooks.my_hook:main"
+   ```
+
+3. **Add any required dependencies** with `poetry add <dep>` followed by `poetry lock`.
+
+4. **Define the hook** in [`.pre-commit-hooks.yaml`](./.pre-commit-hooks.yaml) using the console script name as `entry`:
+
+   ```yaml
+   - id: my-hook
+     name: my-hook
+     description: Run a Python pre-commit hook
+     entry: my-hook
+     language: python
+     pass_filenames: false
+   ```
+
+   > **Why a console script?** Tools like [prek](https://github.com/domodwyer/prek) resolve `entry` as an installed binary rather than a shell command, so `python -m ...` does not work. Registering a console script in `pyproject.toml` ensures the hook runs correctly with both pre-commit and prek.
+
+### Bash hooks
+
+Place the script at the root of the repo and define the hook in [`.pre-commit-hooks.yaml`](./.pre-commit-hooks.yaml):
+
 ```yaml
 - id: bash-example
   name: bash-example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,18 @@ packages = [{include = "python_hooks"}]
 python = "^3.9"
 toml = "^0.10.2"
 
+[tool.poetry.scripts]
+poetry-app-constraints = "python_hooks.poetry_app_constraints:main"
+poetry-pkg-constraints = "python_hooks.poetry_pkg_constraints:main"
+forbidden-imports = "python_hooks.forbidden_imports:main"
+disallowed-identifiers = "python_hooks.disallowed_identifiers:main"
+dockerfile-poetry = "python_hooks.dockerfile_poetry:main"
+do-not-support-generated-columns = "python_hooks.do_not_support_generated_columns:main"
+validate-branch-name = "python_hooks.validate_branch_name:main"
+image-tag-branch-constraint = "python_hooks.image_tag_branch_constraint:main"
+no-non-spark-buckets-in-spark-projects = "python_hooks.no_non_spark_buckets_in_spark_projects:main"
+no-boto3-in-airflow-dags = "python_hooks.no_boto3_in_airflow_dags:main"
+
 [tool.poetry.group.dev.dependencies]
 black = "24.3.0"
 flake8 = "6.0.0"

--- a/python_hooks/disallowed_identifiers.py
+++ b/python_hooks/disallowed_identifiers.py
@@ -62,7 +62,7 @@ def validate_args(args):
         raise ValueError("Number of replacements does not match the number to check")
 
 
-def main(args):
+def run(args):
     return_code = 0
 
     for file_path in args.file_list:
@@ -71,7 +71,7 @@ def main(args):
     return return_code
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='Flags problematic code and suggests replacement code')
     parser.add_argument('--identifier', type=Identifier, choices=list(Identifier), required=True)
     parser.add_argument('--disallowed', nargs='+', help='Disallowed identifier names to check for in code', required=True)
@@ -80,5 +80,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     validate_args(args)
-    return_code = main(args)
-    sys.exit(return_code)
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/disallowed_identifiers.py
+++ b/python_hooks/disallowed_identifiers.py
@@ -63,6 +63,7 @@ def validate_args(args):
 
 
 def run(args):
+    """Run identifier checks across all provided files and return the combined exit code."""
     return_code = 0
 
     for file_path in args.file_list:
@@ -72,6 +73,7 @@ def run(args):
 
 
 def main():
+    """CLI entry point for the disallowed-identifiers pre-commit hook."""
     parser = argparse.ArgumentParser(description='Flags problematic code and suggests replacement code')
     parser.add_argument('--identifier', type=Identifier, choices=list(Identifier), required=True)
     parser.add_argument('--disallowed', nargs='+', help='Disallowed identifier names to check for in code', required=True)

--- a/python_hooks/do_not_support_generated_columns.py
+++ b/python_hooks/do_not_support_generated_columns.py
@@ -24,6 +24,7 @@ def filter_files(file_list: list[str]) -> list[str]:
 
 
 def main():
+    """CLI entry point for the do-not-support-generated-columns pre-commit hook."""
     parser = argparse.ArgumentParser(description='prevent postgres migrations using generated columns')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()

--- a/python_hooks/do_not_support_generated_columns.py
+++ b/python_hooks/do_not_support_generated_columns.py
@@ -23,18 +23,20 @@ def filter_files(file_list: list[str]) -> list[str]:
     return [file for file in file_list if re.match(FILE_REGEX, os.path.basename(file)).group() >= CUTOFF_DATE]  # type: ignore
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='prevent postgres migrations using generated columns')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()
     return_code = 0
 
-    file_list = args.file_list
-
     # filter files to exlude older migrations
-    filter_file_list = filter_files(file_list)
+    filter_file_list = filter_files(args.file_list)
 
     for file_path in filter_file_list:
         return_code |= check_file(file_path)
 
     sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/do_not_support_generated_columns.py
+++ b/python_hooks/do_not_support_generated_columns.py
@@ -20,7 +20,7 @@ def check_file(filename):
 
 
 def filter_files(file_list: list[str]) -> list[str]:
-    return [file for file in file_list if re.match(FILE_REGEX, os.path.basename(file)).group() >= CUTOFF_DATE]  # type: ignore
+    return [file for file in file_list if (m := re.match(FILE_REGEX, os.path.basename(file))) and m.group() >= CUTOFF_DATE]
 
 
 def main():

--- a/python_hooks/dockerfile_poetry.py
+++ b/python_hooks/dockerfile_poetry.py
@@ -17,6 +17,7 @@ def check_poetry(filename):
 
 
 def main():
+    """CLI entry point for the dockerfile-poetry pre-commit hook."""
     parser = argparse.ArgumentParser(description='Check if Dockerfile specifies a poetry version on install')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()

--- a/python_hooks/dockerfile_poetry.py
+++ b/python_hooks/dockerfile_poetry.py
@@ -16,17 +16,17 @@ def check_poetry(filename):
     return 0  # Indicates success
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check for specific imports')
+def main():
+    parser = argparse.ArgumentParser(description='Check if Dockerfile specifies a poetry version on install')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()
     return_code = 0
 
-    file_list = args.file_list
-    print(file_list)
-
-    # in case there are multiple dockerfiles:
-    for file_path in file_list:
+    for file_path in args.file_list:
         return_code |= check_poetry(file_path)
 
     sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/forbidden_imports.py
+++ b/python_hooks/forbidden_imports.py
@@ -17,6 +17,7 @@ def check_imports(filename, forbidden_classes):
 
 
 def main():
+    """CLI entry point for the forbidden-imports pre-commit hook."""
     parser = argparse.ArgumentParser(description='Check for specific imports')
     parser.add_argument('--forbidden_classes', nargs='+', help='Names of the classes to check in imports')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call

--- a/python_hooks/forbidden_imports.py
+++ b/python_hooks/forbidden_imports.py
@@ -16,7 +16,7 @@ def check_imports(filename, forbidden_classes):
     return 0  # Indicates success
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='Check for specific imports')
     parser.add_argument('--forbidden_classes', nargs='+', help='Names of the classes to check in imports')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
@@ -26,10 +26,13 @@ if __name__ == "__main__":
     if not classes_to_check:
         raise ValueError("No classes to check provided. add `args: ['--forbidden_classes', 'foo', 'bar', '--']` to the pre-commit config")
 
-    file_list = args.file_list
     return_code = 0
 
-    for file_path in file_list:
+    for file_path in args.file_list:
         return_code |= check_imports(file_path, classes_to_check)
 
     sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/image_tag_branch_constraint.py
+++ b/python_hooks/image_tag_branch_constraint.py
@@ -35,15 +35,17 @@ def check_file(filename):
     return 0  # Indicates success
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='Prevents specification of image_tag and branch in DatabricksOperator')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()
-
-    file_list = args.file_list
     return_code = 0
 
-    for file_path in file_list:
+    for file_path in args.file_list:
         return_code |= check_file(file_path)
 
     sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/image_tag_branch_constraint.py
+++ b/python_hooks/image_tag_branch_constraint.py
@@ -36,6 +36,7 @@ def check_file(filename):
 
 
 def main():
+    """CLI entry point for the image-tag-branch-constraint pre-commit hook."""
     parser = argparse.ArgumentParser(description='Prevents specification of image_tag and branch in DatabricksOperator')
     parser.add_argument('file_list', nargs='+', help='List of files to check')  # provided by the pre-commit call
     args = parser.parse_args()

--- a/python_hooks/poetry_app_constraints.py
+++ b/python_hooks/poetry_app_constraints.py
@@ -55,8 +55,12 @@ def validate_package_constraint(dep_name: str, constraint: str) -> int:
     return 0
 
 
-if __name__ == '__main__':
+def main():
     parser = ArgumentParser(description="Validate dependency constraint formats for Python application repos.")
     parser.add_argument("--ignore", nargs='+', default=[], help="List of packages to ignore constraint checking for.")
     args = parser.parse_args()
     exit(validate_constraints(args.ignore))
+
+
+if __name__ == '__main__':
+    main()

--- a/python_hooks/poetry_pkg_constraints.py
+++ b/python_hooks/poetry_pkg_constraints.py
@@ -56,6 +56,7 @@ def validate_package_constraint(dep_name: str, constraint: str) -> int:
 
 
 def main():
+    """CLI entry point for the poetry-pkg-constraints pre-commit hook."""
     parser = ArgumentParser(description="Validate dependency constraint formats for Python package repos.")
     parser.add_argument("--ignore", nargs='+', default=[], help="List of packages to ignore constraint checking for.")
     args = parser.parse_args()

--- a/python_hooks/poetry_pkg_constraints.py
+++ b/python_hooks/poetry_pkg_constraints.py
@@ -55,8 +55,12 @@ def validate_package_constraint(dep_name: str, constraint: str) -> int:
     return 0
 
 
-if __name__ == '__main__':
+def main():
     parser = ArgumentParser(description="Validate dependency constraint formats for Python package repos.")
     parser.add_argument("--ignore", nargs='+', default=[], help="List of packages to ignore constraint checking for.")
     args = parser.parse_args()
     exit(validate_constraints(args.ignore))
+
+
+if __name__ == '__main__':
+    main()

--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -18,7 +18,7 @@ def validate_branch_name(branch) -> int:
     return 1
 
 
-if __name__ == "__main__":
+def main():
     # use GITHUB_REF_NAME, set from github actions, if available.
     # Github actions does a shallow clone of the repo with only the first commit by default, so no branch names are available.
     branch = os.environ.get('GITHUB_REF_NAME')
@@ -28,3 +28,7 @@ if __name__ == "__main__":
 
     return_code = validate_branch_name(branch)
     sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -19,6 +19,7 @@ def validate_branch_name(branch) -> int:
 
 
 def main():
+    """CLI entry point for the validate-branch-name pre-commit hook."""
     # use GITHUB_REF_NAME, set from github actions, if available.
     # Github actions does a shallow clone of the repo with only the first commit by default, so no branch names are available.
     branch = os.environ.get('GITHUB_REF_NAME')

--- a/tests/python/test_disallowed_identifiers.py
+++ b/tests/python/test_disallowed_identifiers.py
@@ -8,7 +8,7 @@ import pytest
 from python_hooks.disallowed_identifiers import check_identifiers
 from python_hooks.disallowed_identifiers import DISALLOWED_MESSAGE
 from python_hooks.disallowed_identifiers import Identifier
-from python_hooks.disallowed_identifiers import main
+from python_hooks.disallowed_identifiers import run as main
 from python_hooks.disallowed_identifiers import validate_args
 from python_hooks.utills.ignore_check import IdentifierCheck
 


### PR DESCRIPTION
SRE-3704

All Python hooks used `entry: python -m module` which fails with prek v0.3.8 on Ubuntu 24.04. Unlike pre-commit, prek does not activate a venv and run an arbitrary shell command — it looks up the first word of `entry` as a console script installed from the hook package. On Ubuntu 24.04 there is no `python` binary (only `python3`), so the lookup fails.

**Changes:**
- `pyproject.toml` — add `[tool.poetry.scripts]` entries for all Python hooks
- Each `.py` module — extract `__main__` logic into a no-arg `main()` function (console script entry point)
- `.pre-commit-hooks.yaml` — change every `entry: python -m python_hooks.X` to the console script name (e.g. `poetry-app-constraints`)
- `disallowed_identifiers` — rename internal `main(args)` → `run(args)` to free the name for the no-arg entry point; update tests accordingly

**Backward compatibility with pre-commit:** pre-commit pip-installs the hook package into a venv and prepends `venv/bin/` to PATH before running `entry`, so registered console scripts resolve correctly. No behavioral change for pre-commit consumers.

**Semver:** `entry` fields are consumer-visible interface; tagging as v1.6.0.