### PR TITLE
validate-branch-name: resolve the branch from HEAD, not from `git branch --contains`

### DIFF
--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -36,7 +36,15 @@ def _branch_name_from_git() -> str | None:
 
 
 def _branch_name_from_env() -> str | None:
-    """Return the branch name Github Actions advertises, or None when it isn't usable."""
+    """Return GITHUB_REF_NAME, or None when it isn't usable.
+
+    GITHUB_REF_NAME is the branch name on a `push` event. On a `pull_request` event it is
+    instead the synthetic `<pr_number>/merge` ref -- the source branch name lives in
+    GITHUB_HEAD_REF, which this function does not read. A `pull_request`-triggered run
+    therefore does not currently validate the real branch name: it validates the merge
+    ref, which happens to satisfy this hook's own branch-name pattern and so passes
+    silently.
+    """
     # Github Actions checks out a detached HEAD, so git cannot name the branch there.
     # Treat an empty value the same as an unset one: an empty string is not a branch name.
     return os.environ.get('GITHUB_REF_NAME', '').strip() or None

--- a/python_hooks/validate_branch_name.py
+++ b/python_hooks/validate_branch_name.py
@@ -1,7 +1,7 @@
 import os
 import re
+import subprocess
 import sys
-from subprocess import check_output
 
 
 # regex patterns for acceptable branch names
@@ -10,26 +10,62 @@ from subprocess import check_output
 EXPECTED_PATTERN = r"^(?![-.])[a-zA-Z0-9._/-]{1,50}$"
 ERROR_MESSAGE = "branch name can't start with hyphen or period, cant be more than 50 characters, and can only contain letters, numbers, and special the characters: ._-/"
 
+# `git rev-parse --abbrev-ref HEAD` reports this literal string when HEAD is detached.
+DETACHED_HEAD = 'HEAD'
 
-def validate_branch_name(branch) -> int:
+
+def validate_branch_name(branch: str) -> int:
     if re.match(EXPECTED_PATTERN, branch):
         return 0
     print(ERROR_MESSAGE)
+    print(f'got branch name: {branch!r}')
     return 1
 
 
-def main():
-    """CLI entry point for the validate-branch-name pre-commit hook."""
-    # use GITHUB_REF_NAME, set from github actions, if available.
-    # Github actions does a shallow clone of the repo with only the first commit by default, so no branch names are available.
-    branch = os.environ.get('GITHUB_REF_NAME')
-    if branch is None:
-        commit = check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
-        branch = check_output(["git", "branch", "--contains", commit]).strip().decode('utf-8').split('\n')[-1].strip(' *')
+def _branch_name_from_git() -> str | None:
+    """Return the checked-out branch name, or None when HEAD is detached or git can't answer."""
+    try:
+        output = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        # not a git repo, git not installed, or an unborn HEAD with no commits yet
+        return None
+    branch = output.strip().decode('utf-8')
+    if not branch or branch == DETACHED_HEAD:
+        return None
+    return branch
 
-    return_code = validate_branch_name(branch)
-    sys.exit(return_code)
+
+def _branch_name_from_env() -> str | None:
+    """Return the branch name Github Actions advertises, or None when it isn't usable."""
+    # Github Actions checks out a detached HEAD, so git cannot name the branch there.
+    # Treat an empty value the same as an unset one: an empty string is not a branch name.
+    return os.environ.get('GITHUB_REF_NAME', '').strip() or None
+
+
+def resolve_branch_name() -> str | None:
+    """Return the name of the branch being committed to, or None if it cannot be determined.
+
+    git is the source of truth: `rev-parse --abbrev-ref HEAD` names the branch that is actually
+    checked out. Do not infer the name from `git branch --contains HEAD` -- that lists every local
+    branch containing the commit, in alphabetical order, decorated with `*` for the current branch
+    and `+` for a branch checked out in another worktree, so picking a line out of it returns an
+    unrelated branch (or a `+`-prefixed, unparseable one) whenever more than one branch is a match.
+    """
+    return _branch_name_from_git() or _branch_name_from_env()
+
+
+def main() -> int:
+    """CLI entry point for the validate-branch-name pre-commit hook."""
+    branch = resolve_branch_name()
+    if branch is None:
+        # Detached HEAD with no Github Actions ref to fall back on: rebase, bisect, or a bare
+        # checkout by commit sha. There is no branch name to validate, and a branch-name linter
+        # should never be the thing that blocks such a run.
+        print('no branch name available (detached HEAD and no GITHUB_REF_NAME); skipping check')
+        return 0
+
+    return validate_branch_name(branch)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/python/test_validate_branch_name.py
+++ b/tests/python/test_validate_branch_name.py
@@ -107,10 +107,11 @@ def test_detached_head_without_a_github_actions_ref_is_skipped(repo, monkeypatch
 
 
 def test_an_empty_github_actions_ref_is_treated_as_unset(repo, monkeypatch):
+    git(repo, 'checkout', '--detach', 'HEAD')
     monkeypatch.setenv('GITHUB_REF_NAME', '')
     monkeypatch.chdir(repo)
 
-    assert resolve_branch_name() == 'main'
+    assert resolve_branch_name() is None
     assert main() == 0
 
 

--- a/tests/python/test_validate_branch_name.py
+++ b/tests/python/test_validate_branch_name.py
@@ -1,4 +1,38 @@
+import os
+import subprocess
+
+import pytest
+
+from python_hooks.validate_branch_name import main
+from python_hooks.validate_branch_name import resolve_branch_name
 from python_hooks.validate_branch_name import validate_branch_name
+
+
+# keep the test repos independent of whatever the developer has in their global/system git config
+GIT_SETTINGS = {
+    'user.name': 'pre-commit-hooks tests',
+    'user.email': 'sre@tatari.tv',
+    'commit.gpgsign': 'false',
+    'init.defaultBranch': 'main',
+}
+GIT_CONFIG = [arg for setting, value in GIT_SETTINGS.items() for arg in ('-c', f'{setting}={value}')]
+GIT_ENV = {**os.environ, 'GIT_CONFIG_GLOBAL': os.devnull, 'GIT_CONFIG_SYSTEM': os.devnull}
+
+
+def git(cwd, *args) -> str:
+    return subprocess.run(['git', *GIT_CONFIG, *args], cwd=cwd, check=True, capture_output=True, text=True, env=GIT_ENV).stdout
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A git repo with one commit, checked out on `main`."""
+    root = tmp_path / 'repo'
+    root.mkdir()
+    git(root, 'init')
+    (root / 'file.txt').write_text('contents\n')
+    git(root, 'add', 'file.txt')
+    git(root, 'commit', '--no-verify', '-m', 'initial commit')
+    return root
 
 
 def test_validate_branch_name():
@@ -14,7 +48,75 @@ def test_validate_branch_name():
         ("-ABC12345/abcdABC", 1),  # starts with hyphen
         ("once_upon_a_time_there_was_a_branch_name_that_told_a_very_long_story", 1),  # over 50 characters
         ("ABC-123/abc&123", 1),  # includes non-allowed symbols
+        ("", 1),  # empty string is not a branch name
     ]
 
     for branch, exit_code in branch_names_with_exit_code:
         assert validate_branch_name(branch) == exit_code
+
+
+def test_resolves_the_checked_out_branch_when_several_branches_contain_head(repo, tmp_path, monkeypatch):
+    """Regression test: the first commit on a new branch, in a repo that has other worktrees.
+
+    Before this was fixed the branch name was inferred from `git branch --contains HEAD`, which is
+    every local branch containing the commit -- alphabetically ordered, and prefixed with `+` when
+    the branch is checked out in another worktree. The hook read the last line of that listing, so
+    it validated an unrelated branch name, and failed outright when that line carried a `+`.
+    """
+    git(repo, 'branch', 'zz/checked-out-in-another-worktree')
+    git(repo, 'worktree', 'add', str(tmp_path / 'other-worktree'), 'zz/checked-out-in-another-worktree')
+    git(repo, 'checkout', '-b', 'feature/current-work')
+
+    # the exact shape that used to misfire: >1 branch contains HEAD, the current branch is not the
+    # last line, and the last line is decorated with `+` because of the linked worktree
+    contained = git(repo, 'branch', '--contains', 'HEAD').strip().splitlines()
+    assert len(contained) == 3
+    assert contained[-1].strip(' *') == '+ zz/checked-out-in-another-worktree'
+
+    monkeypatch.delenv('GITHUB_REF_NAME', raising=False)
+    monkeypatch.chdir(repo)
+    assert resolve_branch_name() == 'feature/current-work'
+    assert main() == 0
+
+
+def test_git_is_preferred_over_the_github_actions_ref(repo, monkeypatch):
+    git(repo, 'checkout', '-b', 'feature/checked-out-locally')
+    monkeypatch.setenv('GITHUB_REF_NAME', 'some/other-ref')
+    monkeypatch.chdir(repo)
+
+    assert resolve_branch_name() == 'feature/checked-out-locally'
+
+
+def test_detached_head_falls_back_to_the_github_actions_ref(repo, monkeypatch):
+    git(repo, 'checkout', '--detach', 'HEAD')
+    monkeypatch.setenv('GITHUB_REF_NAME', 'feature/from-github-actions')
+    monkeypatch.chdir(repo)
+
+    assert resolve_branch_name() == 'feature/from-github-actions'
+    assert main() == 0
+
+
+def test_detached_head_without_a_github_actions_ref_is_skipped(repo, monkeypatch):
+    """A rebase, bisect or sha checkout has no branch name, and must not fail the commit."""
+    git(repo, 'checkout', '--detach', 'HEAD')
+    monkeypatch.delenv('GITHUB_REF_NAME', raising=False)
+    monkeypatch.chdir(repo)
+
+    assert resolve_branch_name() is None
+    assert main() == 0
+
+
+def test_an_empty_github_actions_ref_is_treated_as_unset(repo, monkeypatch):
+    monkeypatch.setenv('GITHUB_REF_NAME', '')
+    monkeypatch.chdir(repo)
+
+    assert resolve_branch_name() == 'main'
+    assert main() == 0
+
+
+def test_outside_a_git_repo_is_skipped(tmp_path, monkeypatch):
+    monkeypatch.delenv('GITHUB_REF_NAME', raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_branch_name() is None
+    assert main() == 0


### PR DESCRIPTION
## The bug

`validate-branch-name` inferred the branch name like this:

```python
commit = check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
branch = check_output(["git", "branch", "--contains", commit]).strip().decode('utf-8').split('\n')[-1].strip(' *')
```

`git branch --contains <commit>` is not "the current branch". It is *every* local branch that contains the commit, printed in alphabetical order, with `*` in front of the current branch and `+` in front of a branch that is checked out in another worktree. Taking `[-1]` picks whichever branch sorts last, and `.strip(' *')` does not strip `+`, so a `+` line yields a string that can never be a valid branch name and the hook fails the commit.

## Blast radius

This fires on the **first commit of any new branch, in any repo that has more than one worktree**.

On the first commit of a new branch, the hook runs before that commit exists, so HEAD is still the branch point - which is contained by `main` and by every other branch cut from it. On later commits HEAD is unique to the branch, `--contains` returns one line, and the hook passes. So the same branch fails once and then never again, and which branch name gets validated depends on the alphabetical ordering of unrelated branch names. From the developer's side it looks random and the error message names a rule the branch does not actually break, so the natural response is `git commit --no-verify`, which switches off every hook in the repo.

## Reproduction

```console
$ git init repo && cd repo && git commit -m init --allow-empty
$ git branch zz/checked-out-in-another-worktree
$ git worktree add ../other zz/checked-out-in-another-worktree
$ git checkout -b feature/current-work

$ git branch --contains HEAD
* feature/current-work
  main
+ zz/checked-out-in-another-worktree

$ validate-branch-name          # before
branch name can't start with hyphen or period, cant be more than 50 characters, ...
exit 1                          # it validated '+ zz/checked-out-in-another-worktree'

$ validate-branch-name          # after
exit 0                          # it validated 'feature/current-work'
```

## The fix

Resolve the branch with `git rev-parse --abbrev-ref HEAD`, which names the checked-out branch directly and does not care what other branches contain HEAD or how many worktrees exist.

Detached HEAD is handled explicitly, because `--abbrev-ref` reports the literal string `HEAD` in that state and `HEAD` is not a branch name. The order is now: git, then `GITHUB_REF_NAME`, then skip.

- **git first.** Locally this is always right. For a `push` event, `actions/checkout` puts CI on a real branch, so it is right there too.
- **`GITHUB_REF_NAME` as the fallback.** This is the branch name on a `push` event. On a `pull_request` event it is instead the synthetic `<pr_number>/merge` ref -- the source branch name lives in `GITHUB_HEAD_REF`, which this fallback does not read (see Follow-up below). Empty is now treated as unset: previously `GITHUB_REF_NAME=` (set but empty, which some CI wiring does) validated the empty string and failed.
- **Skip when there is no name at all.** A rebase, a bisect, or a checkout by sha has no branch name to check, and a branch-name linter should not be the thing that blocks that run. It exits 0 with a note instead.

Failures now print the name that was rejected, so the next person does not have to guess which string the hook was looking at.

## Tests

The regression test builds a real repo in the shape that misfired: three branches contain HEAD, one of them checked out in a linked worktree so the `+` prefix is present, and the current branch is not the last line. It asserts that listing's shape as well as the resolved name, so it fails if anyone reintroduces line-picking from `--contains`. Also covered: git wins over `GITHUB_REF_NAME`, detached HEAD falls back to `GITHUB_REF_NAME`, detached HEAD with nothing set skips, empty `GITHUB_REF_NAME` is treated as unset, and outside a git repo skips.

`make unit-test` (140 passed), `make type-check`, black and flake8 all clean. Tests also verified under Python 3.10, the version CI pins.

## Follow-up

`GITHUB_REF_NAME` is `<pr_number>/merge` on `pull_request` events, not the source branch name, and `42/merge` happens to satisfy this hook's own branch-name pattern. So a `pull_request`-triggered run currently validates the merge ref and passes without ever checking the real branch name. That is pre-existing behavior (this env var was read the same way before this PR, added in commit `0b37c14`), not a regression introduced here, so it is intentionally out of scope for this PR.

The correct fix is to read `GITHUB_HEAD_REF` before `GITHUB_REF_NAME` so `pull_request`-triggered CI actually enforces the check. That is deferred to its own PR: this package is consumed as a pre-commit hook by other repos' CI, and turning today's silent pass into real enforcement can newly fail downstream PRs whose branch names don't match the pattern. That downstream breakage deserves to be the headline of its own PR, not a footnote here.

